### PR TITLE
Replace INSERT ON DUPLICATE KEY by INSERT VALUES

### DIFF
--- a/lib/Roundcube/rcube_qmailforward_storage_mysql.php
+++ b/lib/Roundcube/rcube_qmailforward_storage_mysql.php
@@ -162,19 +162,10 @@ class rcube_qmailforward_storage_mysql extends rcube_qmailforward_storage
             // simple redirect with no copy on mailbox
             if ($_POST['forward_action'] == 'redirect') {
                 $sql = "INSERT INTO ".$this->table_name.
-                    " (" . $this->alias_field . ", " .
-                        $this->domain_field. ", " .
-                        $this->valias_field .", " .
-                        $this->copy_field .", " .
-                        $this->type_field .
-                    ")" .
-                    " VALUES (" .
-                        "'" . $user .  "', " .
-                        "'" . $domain .  "', " .
-                        "'" . $valias_line .  "', " .
-                        "0, " .
-                        "1" .
-                    ")";
+                       " SET ".$this->alias_field. "='".$user.  "', ".
+                               $this->domain_field."='".$domain."', ".
+                               $this->valias_field."='".$valias_line."', ".
+                               $this->copy_field.  "=0";
 
                 $this->db->query($sql);
                 return $this->db->affected_rows() != 0;
@@ -183,19 +174,10 @@ class rcube_qmailforward_storage_mysql extends rcube_qmailforward_storage
             else if ($_POST['forward_action'] == 'copy') {
                 // save the forward record
                 $sql = "INSERT INTO ".$this->table_name.
-                    " (" . $this->alias_field . ", " .
-                        $this->domain_field. ", " .
-                        $this->valias_field . ", " .
-                        $this->copy_field . ", " .
-                        $this->type_field .
-                    ")" .
-                    " VALUES (" .
-                        "'" . $user . "', ". 
-                        "'" . $domain . "', " .
-                        "'" . $valias_line . "', " .
-                        "1, " .
-                        "1" .
-                    ")";
+                       " SET ".$this->alias_field. "='".$user.  "', ".
+                               $this->domain_field."='".$domain."', ".
+                               $this->valias_field."='".$valias_line."', ".
+                               $this->copy_field.  "=1";
 
                 $this->db->query($sql);
                 if (!$this->db->affected_rows()) return false;

--- a/qmailforward.php
+++ b/qmailforward.php
@@ -33,6 +33,7 @@
 class qmailforward extends rcube_plugin
 {
     public  $task = 'settings';
+    private $rc;
     private $storage;
     private $user;
     private $domain;


### PR DESCRIPTION
As PRIMARY is anymore used, I repalce INSERT UPDATE, by standart INSERT VALUE.
I remove the _delete all eventually present lda records_  parts as this entry was already removed previously.
I Fix some deprecated php _PHP Deprecated:  Creation of dynamic property_.
As the return must be boolean, I change the way return value is managed.